### PR TITLE
FHIR-33349: Allow gender in fallback profile

### DIFF
--- a/input/fsh/profiles_admin.fsh
+++ b/input/fsh/profiles_admin.fsh
@@ -24,11 +24,21 @@ Description: "Slight modification of Patient, with identifier as 0..0 and limite
 * birthDate MS
 * birthDate ^comment = "If exact date of birth is partially or completely unknown, Issuers SHALL populate this element with the date of birth information listed on the patient's government-issued identification. This MAY include a partial date of birth like `1999` or `1999-01`, or \"filler\" for unknown portions. (E.g., if a patient was born in 1950 but does not know the month or day, their government-issued identification may fill the month and day with `-01-01`. In this case, it is acceptable to populate this element with `1950-01-01` even if it is known the patient was not actually born on January 1.) If date of birth is completely unknown and no government-issued identification is available, Issuers MAY omit this element."
 
-* gender 0..0
-* gender ^short = "SHALL not be included"
-* gender ^comment = "Self-identified gender may change over time, and it may not be possible to re-issue a credential updating the value of this element. Including this element could therefore create a situation where the gender element in the credential does not match that in another form of identification, or does not match the Holder's self-identified gender at the time they present their credential to a Verifier.
+* gender 0..1
+* gender ^short = "Administrative gender"
+* gender obeys use-only-if-required-by-law
+* gender ^definition = "Administrative gender.
 
-Because gender is a common field in administrative data, it is possible Issuers will include it without considering the potential harms to Holders as described above. We have therefore disallowed this element in both the allowable and data minimization profiles."
+Issuers SHALL NOT include `gender` unless required by law in the jurisdiction where the SMART Health Card is issued.
+
+Verifiers SHALL NOT use `gender` in their workflows unless required by law in both the jurisdiction where the SMART Health Card was issued and the jurisdiction governing the Verifier."
+* gender ^comment = "SMART Health Cards cannot be used as a form of identification. From the [SMART Health Card specification](https://spec.smarthealth.cards/#can-a-smart-health-card-be-used-as-a-form-of-identification):
+
+_\"SMART Health Cards are designed for use alongside existing forms of identification (e.g., a driver's license in person, or an online ID verification service). A SMART Health Card is a non-forgeable digital artifact analogous to a paper record on official letterhead. Concretely, the problem SMART Health Cards solve is one of provenance: a digitally signed SMART Health Card is a credential that guarantees that a specific issuer generated the record. The duty of verifying that the person presenting a Health Card is the subject of the data within the Health Card (or is authorized to act on behalf of this data subject) falls to the person or system receiving and validating a Health Card.\"_
+
+To facilitate verifying that the person presenting a Health Card is the subject of the data within the Health Card (or is authorized to act on behalf of this data subject), the patient's name and date of birth are included the SMART Health Card. **Gender is typically not included** because name and date of birth are sufficient for verification workflows, and there may be legitimate reasons why gender in a SMART Health Card does not match that in an existing form of identification (e.g., a change in administrative gender, or differences in how gender is represented). Note that it may not be possible to get a re-issued SMART Health Card if a patient's administrative gender changes.
+
+Additionally, patients may not wish to share their administrative gender with Verifiers. Since this information is typically not necessary for the Verifiers' use case, it should be omitted as is consistent with the [privacy by design](index.html#privacy-by-design) approach used throughout this IG."
 
 * photo 0..0
 * photo ^comment = "Attachments are not allowed due to data size constraints."
@@ -54,6 +64,13 @@ RuleSet: contact-information-should-not-be-populated(path)
 * {path} obeys vc-should-be-omitted-privacy
 * {path} ^comment = "For patient privacy reasons, this element SHALL NOT be populated unless the Issuer believes the credential cannot be verified in its absence."
 
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+Invariant:   use-only-if-required-by-law
+Description: "SHALL be omitted UNLESS required by law in jurisdiction where SHC is issued"
+Expression:  "$this.length() = 0"
+Severity:    #warning
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -99,6 +116,7 @@ Description: "Only elements necessary for Verifiers can be populated."
 * identifier 0..0
 * identifier ^definition = "Identifer is not allowed in this IG due to risk of accidental, unnecessary exposure of sensitive identifiers to verifiers. For use in the United States."
 
+* gender 0..0
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/input/fsh/rulesets.fsh
+++ b/input/fsh/rulesets.fsh
@@ -1,6 +1,6 @@
 RuleSet: id-should-not-be-populated(path)
 * {path}id ^short = "Should not be populated"
-* {path}id ^definition = "For [data minimization reasons](profiles.html#data-minimization), this element SHOULD NOT be populated when generating a resource conforming to this profile for inclusion in one of the Bundles profiled in this IG."
+* {path}id ^definition = "For [data minimization reasons](profiles.html#data-minimization-and-privacy), this element SHOULD NOT be populated when generating a resource conforming to this profile for inclusion in one of the Bundles profiled in this IG."
 * {path}id ^comment = "Not including `id` may result in FHIR validation errors of resources. These errors can be ignored for the purposes of assessing conformance to this IG."
 
 RuleSet: reference-to-absolute-uri(path)

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -2,8 +2,17 @@
 
 # Suppress errors related to relative links that the Publisher is turning into the wrong absolute links
 # Reported as https://github.com/HL7/fhir-ig-publisher/issues/245
-The link 'http://hl7.org/fhir/R4/profiles.html#data-minimization' for "data minimization reasons" cannot be resolved
-The link 'http://hl7.org/fhir/R4/conformance.html' for "conformance requirements" cannot be resolved
+The link 'StructureDefinition-shc-covid19-laboratory-result-observation-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-infectious-disease-laboratory-result-observation-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-ad.html/index.html#privacy-by-design' for "privacy by design" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-ad.html/index.html#privacy-by-design' for "privacy by design" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-dm.html/StructureDefinition-shc-patient-general-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-patient-general-dm.html/StructureDefinition-shc-patient-general-ad.html/index.html#privacy-by-design' for "privacy by design" cannot be resolved
+The link 'StructureDefinition-shc-vaccination-ad.html/profiles.html#data-minimization-and-privacy' for "data minimization reasons" cannot be resolved
+The link 'StructureDefinition-shc-vaccination-ad.html/conformance.html' for "conformance requirements" cannot be resolved
+
 
 # Suppress errors related to not having examples. We do in fact have examples for all profiles, but they are linked to on GitHub rather than as part of the standard IG build process. The reason for this is that the IG publisher build process won't allow us to exclude `Resource.id`, `Resource.meta`, and `Resource.text` in examples. These elements SHOULD NOT be included in resources conforming to our IG, so having examples that include them would be confusing for implementers. Reported as https://github.com/HL7/fhir-ig-publisher/issues/293
 WARNING: StructureDefinition.where(url = 'http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-covid19-laboratory-bundle-ad'): The Implementation Guide contains no examples for this profile

--- a/input/includes/profile-set-nav.md
+++ b/input/includes/profile-set-nav.md
@@ -112,7 +112,7 @@
 </script>
 
 {% if page.path contains "-ad.html" %}
-**Note!** This is a [fallback "allowable data" (AD) profile](profiles.html#data-minimization). Implementers should validate against the [primary "data minimization" (DM) profile if possible]({{ page.path | replace: '-ad.html', '-dm.html' }}).
+**Note!** This is a [fallback "allowable data" (AD) profile](profiles.html#data-minimization-and-privacy). Implementers should validate against the [primary "data minimization" (DM) profile if possible]({{ page.path | replace: '-ad.html', '-dm.html' }}).
 {: .alert.alert-danger }
 {% endif %}
 
@@ -148,4 +148,17 @@
             if(id == "ui-id-4") window.location.hash = "#tab-ms";
         })
     });
+
+    // Make gender invariant more visible
+    if(window.location.pathname.split('/').pop() == 'StructureDefinition-shc-patient-general-ad.html') {
+      document.addEventListener('DOMContentLoaded', function() {
+        var newPageName = window.location.pathname.split('/').pop().replace('.html', '-definitions.html');
+        jQuery('#tabs span:contains("use-only-if-required-by-law")').css('color', 'red');
+        // Code point 60 is the "less than sign" -- putting the character directly in caused a
+        // parsing error with the IG Publisher's facility for validating HTML.
+        var lessThanSign = String.fromCodePoint(60)
+        var toAppend = `. For more information see here ${lessThanSign}a href="${newPageName}#Patient.gender">here${lessThanSign}/a>.`
+        jQuery('#tabs span:contains("use-only-if-required-by-law")').parent().append(toAppend);
+      });
+    }
 </script>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -17,7 +17,7 @@ The primary actors are:
 1. **Holders** who receive a [SMART Health Card] from an Issuer (which contains the FHIR resources described in this IG), and may display it to a Verifier.
 1. **Verifiers** who read and analyze the FHIR resources described in this IG.
 
-Issuers and Verifiers are considered "implementers" of this IG.
+Issuers and Verifiers are considered "implementers" of this IG. Additionally, "wallet applications" used by Holders to store digital versions of their SHC are also considered implementers.
 
 #### Privacy by design
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -9,7 +9,6 @@ This [FHIR Implementation Guide](https://www.hl7.org/fhir/implementationguide.ht
 
 Note that this IG is not directly related to the [SMART App Launch Framework](http://www.hl7.org/fhir/smart-app-launch/). The name comes from [SMART Health IT](https://smarthealthit.org/), who also developed the [SMART Health Card] framework that this IG supports. SMART App Launch and SMART Health Cards are designed to work well together (the former being one of multiple methods for issuing the latter), but they don't have a hard dependency with each other.
 
-
 ### Actors
 
 The primary actors are:
@@ -20,11 +19,24 @@ The primary actors are:
 
 Issuers and Verifiers are considered "implementers" of this IG.
 
+#### Privacy by design
+
+Special attention is payed in this IG to protecting the privacy of Holders.
+
+The design of the SMART Health Card specification results in the following characteristics of issued SMART Health Cards:
+
+1. The contents cannot be changed (without re-issuing the entire SMART Health Card).
+2. The entirety of the data within the SMART Health Card is transmitted from the Holder to the Verifier whenever a SMART Health Card is presented.
+
+**Therefore, information that is not strictly necessary for a legitimate Verifier use case SHALL NOT be included in SMART Health Cards.**
+
+For more information, please see [the data minimization and privacy section on the Profiles page](profiles.html#data-minimization-and-privacy).
+
 ### Use cases
 
 Our primary focus is on the use case of representing the minimal set of clinical data necessary to represent COVID-19 vaccination status and laboratory testing for verification purposes in a SMART Health Card. We support other infectious diseases as a secondary use case. To meet these use cases, we provide profiles of a [FHIR Bundle](https://www.hl7.org/fhir/bundle.html) that describes the contents of [the `fhirBundle` element in a SMART Health Card](https://spec.smarthealth.cards/#data-model). We also provide profiles of the resources contained within this Bundle.
 
-The SMART Health Cards Framework constrains the size of the FHIR payload embedded within a SMART Health Card to allow the entirety of the SMART Health Card to fit within [a single Version 22 QR code](https://spec.smarthealth.cards/#chunking). This IG is designed to support creating resources that fit within these size constraints. (While it is possible to generate a [denser QR code](https://www.qrcode.com/en/about/version.html), the [SMART Health Cards Framework](https://spec.smarthealth.cards/#every-health-card-can-be-embedded-in-a-qr-code) developers found that denser QR codes could be difficult to scan.) SMART Health Card payloads are compressed, so the precise number of available uncompressed bytes for the embedded FHIR Bundle is not knowable (the compression ratio depends on the specific content being compressed). In practice, we have found that bundles of resources conforming to the [data minimization profiles](profiles.html#data-minimization) in this IG do fit within the payload constraints.
+The SMART Health Cards Framework constrains the size of the FHIR payload embedded within a SMART Health Card to allow the entirety of the SMART Health Card to fit within [a single Version 22 QR code](https://spec.smarthealth.cards/#chunking). This IG is designed to support creating resources that fit within these size constraints. (While it is possible to generate a [denser QR code](https://www.qrcode.com/en/about/version.html), the [SMART Health Cards Framework](https://spec.smarthealth.cards/#every-health-card-can-be-embedded-in-a-qr-code) developers found that denser QR codes could be difficult to scan.) SMART Health Card payloads are compressed, so the precise number of available uncompressed bytes for the embedded FHIR Bundle is not knowable (the compression ratio depends on the specific content being compressed). In practice, we have found that bundles of resources conforming to the [data minimization profiles](profiles.html#data-minimization-and-privacy) in this IG do fit within the payload constraints.
 
 Due to these size constraints and to preserve patient privacy, information that is not necessary for Verifiers SHALL NOT be included in SMART Health Cards. With respect to patient privacy, note that when a SMART Health Card is issued, it is [cryptographically signed](https://spec.smarthealth.cards/#signing-health-cards) by the Issuer. This means that the contents, including the FHIR Bundle, cannot be changed without invalidating the signature. It is therefore critical for Issuers to exclude any information that could represent a privacy risk to a patient when presenting their SMART Health Card to a Verifier.
 
@@ -42,7 +54,7 @@ Due to these size constraints and to preserve patient privacy, information that 
 * {% assign example = site.data.examples["StructureDefinition-shc-vaccination.html"][2] %}[Immunization resource: {{example.title}}]({{ example.url | replace: 'GIT_BRANCH_GOES_HERE', site.data['git-branch']}}) conforming to [SHCVaccinationDM]
 * {% assign example = site.data.examples["StructureDefinition-shc-vaccination.html"][3] %}[Immunization resource: {{example.title}}]({{ example.url | replace: 'GIT_BRANCH_GOES_HERE', site.data['git-branch']}}) conforming to [SHCVaccinationDM]
 
-The example Bundle resources for both scenarios above conform to [SHCVaccinationBundleDM]. 
+The example Bundle resources for both scenarios above conform to [SHCVaccinationBundleDM].
 
 #### Use case 2: laboratory test results
 
@@ -71,7 +83,7 @@ The IG is currently focused on coordinating implementers' representations of rel
 
 1. More constrained profiles for risk evaluation can be created based on the profiles in this IG, but it's not possible to remove constraints in a child profile.
 
-1. Cardinality constraints are applied to specific data elements in [Allowable Data profiles](profiles.html#data-minimization) when their inclusion (1) does not support our use case and could harm patients; or (2) is contrary to our [key design principles](https://vci.org/about#key-principles). For example, `Patient.identifier` is not allowed in resources conforming to [SHCPatientUnitedStatesDM] as this may include a MRN or SSN in the United States, which would introduce a significant privacy risk for patients.
+1. Cardinality constraints are applied to specific data elements in [Allowable Data profiles](profiles.html#data-minimization-and-privacy) when their inclusion (1) does not support our use case and could harm patients; or (2) is contrary to our [key design principles](https://vci.org/about#key-principles). For example, `Patient.identifier` is not allowed in resources conforming to [SHCPatientUnitedStatesDM] as this may include a MRN or SSN in the United States, which would introduce a significant privacy risk for patients.
 
 ### Approach to terminology bindings
 

--- a/input/pagecontent/profiles.md
+++ b/input/pagecontent/profiles.md
@@ -1,4 +1,4 @@
-This Implementation Guide (IG) includes Data Minimization (DM), which include only the minimum set of elements necessary to create a valid resource, and fallback Allowable Data (AD) profiles. More detail about the difference between DM and AD profiles is available below.
+This Implementation Guide (IG) includes Primary Profiles to ensure data minimization (DM), and Fallback Profiles with relaxed constraints that include all allowable data (AD). More detail about the difference between DM and AD profiles is available below.
 
 ### Profile groups
 
@@ -89,7 +89,7 @@ In this Implementation Guide, "support in some meaningful way" is defined as fol
 
     1. Issuers SHALL populate any elements marked as `MustSupport` **if and only if the necessary data are available in their system**. See [Missing data](#missing-data) below for details.
 
-    1. Issuers SHOULD NOT populate any elements that are not marked as `MustSupport` unless they believe the element contains valuable information for Holders and/or Verifiers. This is due to the payload size constraints of SMART Health Cards; see the [Data minimization](#data-minimization) section below for more details on how to reduce payload size when implementing. To avoid contradicting cardinality, all required elements (minimum cardinality > 0) are therefore also labeled as `MustSupport`.
+    1. Issuers SHOULD NOT populate any elements that are not marked as `MustSupport` unless they believe the element contains valuable information for Holders and/or Verifiers. This is due to the payload size constraints of SMART Health Cards; see the [Data minimization](#data-minimization-and-privacy) section below for more details on how to reduce payload size when implementing. To avoid contradicting cardinality, all required elements (minimum cardinality > 0) are therefore also labeled as `MustSupport`.
 
 - **Verifiers:**
 
@@ -106,13 +106,13 @@ Elements with a minimum [cardinality](https://www.hl7.org/fhir/conformance-rules
 - If an Issuer does not have data for a `MustSupport` data element, the data element SHALL be omitted from the resource. Implementers SHALL NOT produce placeholder data when data are not available; instead, omit the element.
 - If an Issuer does not have data for a required data element (minimum cardinality > 0), the Issuer SHALL NOT produce the resource.
 
-### Data minimization
+### Data minimization and privacy
 
-The FHIR payload within a SMART Health Card SHALL be [small enough](https://spec.smarthealth.cards/#health-cards-are-small) to allow the entirety of the SMART Health Card to fit within [a single Version 22 QR code](https://spec.smarthealth.cards/#chunking). This limits the amount of data that SHOULD be included in FHIR resources that appear in SMART Health Card payloads.
+**To preserve patient privacy, information that is not necessary for Verifiers *SHALL NOT* be included in SMART Health Cards.** With respect to patient privacy, note that when a SMART Health Card is issued, it is [cryptographically signed](https://spec.smarthealth.cards/#signing-health-cards) by the Issuer. This means that the contents, including the FHIR bundle, cannot be changed without invalidating the signature. It is therefore critical for Issuers to exclude any information that could represent a privacy risk to a patient when presenting their SMART Health Card to a Verifier.
 
-To preserve patient privacy, information that is not necessary for Verifiers SHALL NOT be included in SMART Health Cards. With respect to patient privacy, note that when a SMART Health Card is issued, it is [cryptographically signed](https://spec.smarthealth.cards/#signing-health-cards) by the Issuer. This means that the contents, including the FHIR bundle, cannot be changed without invalidating the signature. It is therefore critical for Issuers to exclude any information that could represent a privacy risk to a patient when presenting their SMART Health Card to a Verifier.
+Additionally, FHIR payload within a SMART Health Card SHALL be [small enough](https://spec.smarthealth.cards/#health-cards-are-small) to allow the entirety of the SMART Health Card to fit within [a single Version 22 QR code](https://spec.smarthealth.cards/#chunking). This limits the amount of data that SHOULD be included in FHIR resources that appear in SMART Health Card payloads.
 
-See the [Validation section](#validation) for information on how to validate a resource against a profile.
+To ensure only the minimal amount of data are being included, Issuers SHOULD validate their FHIR resource instances against the primary (DM) profiles listed above. See the [Validation section](#validation) for information on how to validate a resource against a profile.
 
 Additionally:
 
@@ -172,6 +172,14 @@ path/to/immunization.json
 The command above would validate `path/to/immunization.json` against the [SHCVaccinationDM] profile. To validate against a different profile, change `shc-vaccination-dm` to the [identifier](http://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.identifier) of the profile you want to validate against. This can be found at the end of the canonical URL listed at the top of each profile's page in the IG.
 
 Additional [testing and validation tools may be found here](https://confluence.hl7.org/display/PHWG/SMART+Health+Cards+Implementation+Tools).
+
+---
+
+### Jurisdiction-specific profiles
+
+Implementers who wish to request jurisdiction-specific versions of any of the profiles in this IG (like the [United States-specific patient profiles](StructureDefinition-shc-patient-us-dm.html)) should [contact the authors of the IG](index.html#author-contact-information) to request new profiles be added.
+
+Typically, jurisdiction-specific profiles can be added if they benefit the use cases of [the IG's actors](index.html#actors) within that jurisdiction.
 
 {% include markdown-link-references.md %}
 

--- a/input/pagecontent/profiles.md
+++ b/input/pagecontent/profiles.md
@@ -175,11 +175,19 @@ Additional [testing and validation tools may be found here](https://confluence.h
 
 ---
 
-### Jurisdiction-specific profiles
+### Internationalization
 
-Implementers who wish to request jurisdiction-specific versions of any of the profiles in this IG (like the [United States-specific patient profiles](StructureDefinition-shc-patient-us-dm.html)) should [contact the authors of the IG](index.html#author-contact-information) to request new profiles be added.
+The [SMART Health Cards] specification and this IG are suitable for international use.
 
-Typically, jurisdiction-specific profiles can be added if they benefit the use cases of [the IG's actors](index.html#actors) within that jurisdiction.
+Additionally, this IG includes specific profiles for the following jurisdictions:
+
+- United States
+
+Other jurisdictions are welcome to define their own profiles that reflect their local concerns -- please contact the local HL7 affiliate or [the authors of this specification](contact.html) for assistance.
+
+Jurisdictional profiles will typically add constraints to those defined in the "fallback" profiles [defined above](#profile-groups). For example, jurisdictional profiles might add constraints limiting the patient identifier to a specific type of national patient/consumer id, or define a specific value set using codes from a local SNOMED-CT edition for vaccines.
+
+Typically jurisdictional profiles will include both "primary" and "fallback" profiles; both SHALL inherit from the generic "fallback" profile or the generic "primary" profile.
 
 {% include markdown-link-references.md %}
 

--- a/input/pagecontent/vaccination.md
+++ b/input/pagecontent/vaccination.md
@@ -73,7 +73,7 @@ When using multiple codes, the codes SHALL NOT contradict each other. More infor
 
 > More than one code may be used in CodeableConcept. The concept may be coded multiple times in different code systems.... Each coding (also referred to as a 'translation') is a representation of the concept as described above and may have slightly different granularity due to the differences in the definitions of the underlying codes. There is no meaning associated with the ordering of coding within a CodeableConcept.
 
-However, as described above, for [data minimization](profiles.html#data-minimization) reasons, Issuers SHOULD typically include ONLY a single code that is the most granular (i.e., includes the greatest level of detail) of the options available in their system UNLESS they believe another actor may benefit from the additional code. Typically at most two codes will be included in `vaccineCode`: a less granular code paired with a GTIN code to identify manufacturer as described below.
+However, as described above, for [data minimization](profiles.html#data-minimization-and-privacy) reasons, Issuers SHOULD typically include ONLY a single code that is the most granular (i.e., includes the greatest level of detail) of the options available in their system UNLESS they believe another actor may benefit from the additional code. Typically at most two codes will be included in `vaccineCode`: a less granular code paired with a GTIN code to identify manufacturer as described below.
 
 Verifiers SHALL be able to meaningfully process and interpret codes from ALL of the systems listed above.
 


### PR DESCRIPTION
Three major changes here:

### 1) Allow `gender` in [fallback profile](http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/gender/StructureDefinition-shc-patient-general-ad.html)

This goes from being `0..0` to `0..1` (note that the Patient resource has a maximum cardinality of 1).

This includes an invariant with some special formatting:

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/110426/147788051-4f232170-5fc4-428e-9202-529c5679fccf.png">

### 2) Improve narrative related to i18n

See bottom of [this page](http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/gender/profiles.html). This incorporates some of Grahame's suggestions from [Zulip](https://chat.fhir.org/#narrow/stream/284830-smart.2Fhealth-cards/topic/SHC.20FHIR.20IG.20conference.20call.20.28Tue.20Dec.207.2C.204pm.20Eastern.20time.29/near/264097204) (the rest of these suggestions will go into a separate commit/PR).

### 3) Addition of "privacy by design" section on the home page

See [here](http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/gender/index.html#privacy-by-design).

The corresponding section on the [profiles page](http://build.fhir.org/ig/HL7/fhir-shc-vaccination-ig/branches/gender/profiles.html#data-minimization-and-privacy) is also updated.