### PR TITLE
FHIR-33601: Change behavior of name invariant

### DIFF
--- a/input/fsh/invariants.fsh
+++ b/input/fsh/invariants.fsh
@@ -7,8 +7,8 @@ Severity:   #error
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Invariant: vc-name-invariant
-Description: "Require one of the key name elements to be filled. Allows for `text` for names that cannot be cleanly categorized into `family` or `given` (https://www.nature.com/articles/d41586-020-02761-z)."
-Expression: "(family.exists() or given.exists()) xor text.exists()"
+Description: "Require one of the key name elements to be filled. Allows for `text` for names that cannot be cleanly categorized into `family` and `given` (https://www.nature.com/articles/d41586-020-02761-z)."
+Expression: "(family.exists() and given.exists()) xor text.exists()"
 Severity: #error
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/resources/name-invariant-family-only.test.json
+++ b/src/test/resources/name-invariant-family-only.test.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "Patient",
+  "name": [
+    {
+      "family": "Anyperson"
+    }
+  ],
+  "birthDate": "1951-01-20"
+}

--- a/src/test/resources/tests_errors.csv
+++ b/src/test/resources/tests_errors.csv
@@ -2,6 +2,7 @@ example,profile,expectedIssueSeverity,expectedLocation,expectedErrorMessage
 src/test/resources/should-be-omitted.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-vaccination-bundle-dm,WARNING,Bundle.id,vc-should-be-omitted
 src/test/resources/observation-status-shall-be-complete.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-covid19-laboratory-result-observation-ad,ERROR,,vc-observation-status-shall-be-complete
 src/test/resources/name-invariant-xor.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-patient-general-dm,ERROR,,vc-name-invariant
+src/test/resources/name-invariant-family-only.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-patient-general-dm,ERROR,,vc-name-invariant
 src/test/resources/name-invariant-none.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-patient-general-dm,ERROR,,vc-name-invariant
 src/test/resources/date-invariant-with-time.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-vaccination-ad,WARNING,,vc-polymorphic-date-invariant
 src/test/resources/shall-be-true-if-populated-invariant.test.json,http://hl7.org/fhir/uv/shc-vaccination/StructureDefinition/shc-vaccination-ad,ERROR,,vc-shall-be-true-if-populated-invariant


### PR DESCRIPTION
Old behavior was to allow for either (1) `family` *or* `given`; xor (2)
`text`.

If both `family` and `given` cannot be populated, implementers should use
`text` instead.

This updates the invariant to do just that, and also adds a unit test.