### PR TITLE
FHIR-33875: Styling/navigation improvements

### DIFF
--- a/custom-template/content/assets/css/smart-health-cards.css
+++ b/custom-template/content/assets/css/smart-health-cards.css
@@ -35,3 +35,11 @@
 .nav .open > .dropdown-menu {
     display: table-caption;
 }
+
+#segment-content a {
+    text-decoration: underline;
+}
+
+#segment-content .nav a {
+    text-decoration: none;
+}

--- a/input/data/profiles.json
+++ b/input/data/profiles.json
@@ -48,6 +48,7 @@
   "bundles": {
     "name": "Bundles",
     "description": "Defines the contents of the `fhirBundle` element in a SMART Health Card for a given use case.",
+    "instructions": "bundles.html",
     "profileSets": [
       {
         "name": "Immunization Bundle",
@@ -63,18 +64,6 @@
         "name": "Generic Labs Bundle",
         "scope": "Lab results for any infections disease",
         "slug": "shc-infectious-disease-laboratory-bundle"
-      }
-    ]
-  },
-  "experimental": {
-    "suppress": true,
-    "name": "Experimental",
-    "description": "Profiles that are considered experimental and may change without notice.",
-    "profileSets": [
-      {
-        "name": "Experimental: Vaccination Reaction",
-        "scope": "Any infectious disease",
-        "slug": "shc-vaccination-reaction-observation"
       }
     ]
   }

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -1,8 +1,34 @@
 <ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
   <li><a href="index.html">Home</a></li>
-  <li><a href="profiles.html">Profiles</a></li>
+
   <li class="dropdown">
-    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Value Sets<b class="caret"></b></a>
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Profile Groups<b class="caret"></b></a>
+    <ul class="dropdown-menu">
+      <li>
+        <a href="profiles.html">
+          All Profiles
+          <span class="label label-success" style="margin-left: 2em;">Start here!</span>
+        </a>
+      </li>
+
+      <li role="separator" class="divider"></li>
+
+      <li><a href="patient.html">Patient</a></li>
+      <li>
+        <a href="vaccination.html">Vaccination</a>
+      </li>
+      <li>
+        <a href="laboratory-results-observation.html">Lab results</a>
+      </li>
+      <li>
+        <a href="bundles.html">Bundles</a>
+      </li>
+    </ul>
+  </li>
+
+
+  <li class="dropdown">
+    <a data-toggle="dropdown" href="#" class="dropdown-toggle">Terminology<b class="caret"></b></a>
     <ul class="dropdown-menu">
       <li><a href="ValueSet-vaccine-gtin.html">Vaccine: GTIN</a></li>
       <li><a href="ValueSet-vaccine-cvx.html">Vaccine: CVX</a></li>
@@ -21,5 +47,10 @@
     </ul>
   </li>
   <li><a href="https://github.com/HL7/fhir-shc-vaccination-ig">GitHub</a></li>
-  <li><a href="contact.html">Contact the Authors</a></li>
+  <li>
+    <a href="downloads.html">Downloads</a>
+  </li>
+  <li>
+    <a href="contact.html">Contact the Authors</a>
+  </li>
 </ul>

--- a/input/includes/profile-set-nav.md
+++ b/input/includes/profile-set-nav.md
@@ -1,25 +1,25 @@
 {% assign r = site.data.profiles[include.resourceName]  %}
+{% capture url %}{{r.instructions}}{% endcapture %}
+{% if page.path != url %}
+<div style="padding-left: 9.3em; margin-bottom:-1.4em;"><span class="highlight"><strong>&darr;</strong> Start here!</span></div>
+{% endif %}
 <div class="well profile-set-nav" style="background-color: #fff; margin-top: 2em; width: 100%;">
     <div style="font-size: 1.2em; margin-top: -1.7em;">
-      <span style="background-color: #fff; padding-left: 0.5em; padding-right: 0.5em;"><strong>{{ r.name }}:</strong> Profile Group Navigation</span>
+      <span style="background-color: #fff; padding-left: 0.5em; padding-right: 0.5em;">
+        Profile Group:
+        {% if page.path == url %}<strong>{% else %}<a style="font-weight: bold; text-decoration: underline;" href="{{ url }}">{% endif %}
+          {{ r.name }}
+        {% if page.path == url %}</strong>{% else %}</a>{% endif %}
+      </span>
     </div>
     <div style="margin-top: 1em;">
-      <p>{{ r.description }}</p>
-      {% if r.instructions %}
-      <p>
-        {% capture url %}{{r.instructions}}{% endcapture %}
-        <span class="{% if page.path == url %}active-page{% endif %}">
-          <a href="{{ r.instructions }}" class="btn btn-success">Implementation instructions</a>
-          {% if page.path != url %}<span class="highlight"><strong>&#8592;</strong> Start here!</span>{% endif %}
-        </span>
-      </p>
-      {% endif %}
+      <p><strong>Description:</strong> {{ r.description | markdownify }}</p>
       <table class="table">
           <thead>
               <tr>
                   <th>Primary profile (DM)</th>
-                  <th>Fallback Profiles (AD)</th>
-                  <th>Scope</th>
+                  <th>Fallback profile (AD)</th>
+                  <th>Scope of profile pair</th>
               </tr>
           </thead>
           <tbody>
@@ -27,11 +27,11 @@
               <tr>
                   {% capture url %}StructureDefinition-{{ profileSet.slug }}-dm.html{% endcapture %}
                   <td class="{% if page.path == url %}active-page{% endif %}">
-                    <a href="{{ url }}" class="btn">{{ profileSet.name }}</a>
+                    <a href="{{ url }}">{{ profileSet.name }}</a>
                   </td>
                   {% capture url %}StructureDefinition-{{ profileSet.slug }}-ad.html{% endcapture %}
                   <td class="{% if page.path == url %}active-page{% endif %}">
-                      <a href="{{ url }}" class="btn">Fallback</a>
+                      <a href="{{ url }}">Fallback</a>
                   </td>
                   <td>{{ profileSet.scope }}</td>
               </tr>
@@ -100,37 +100,15 @@
     margin-bottom:  0;
   }
 
-
-
-  .profile-set-nav .btn {
-    font-size: inherit;
-    font-weight: normal;
-    border: 1px solid #ccc;
-    color: #333;
-  }
-  .profile-set-nav .btn:hover {
-    background-color: #e6e6e6;
-    border-color: #adadad;
-  }
   .highlight {
       background-color: #fffeca;
   }
-  .profile-set-nav .active-page .btn, .profile-set-nav .active-page .btn:hover {
-      /* background-color: #fffeca; */
-      background: #fbfbfb;
-      color: #da0c23;
-      -webkit-box-shadow: inset 0px 0px 5px #c1c1c1;
-      -moz-box-shadow: inset 0px 0px 5px #c1c1c1;
-      box-shadow: inset 0px 0px 5px #c1c1c1;
-      border: 0;
-      cursor: not-allowed;
-  }
-  .profile-set-nav .btn-success {
-    color: white;
-  }
-  .profile-set-nav .btn-success:hover {
-    background-color: #449d44;
-    border-color: #398439;
+
+  .profile-set-nav .active-page a {
+    color: #eb8f00;
+    font-weight: bold;
+    text-decoration: none !important;
+    cursor: not-allowed;
   }
 </style>
 

--- a/input/pagecontent/bundles.md
+++ b/input/pagecontent/bundles.md
@@ -1,0 +1,8 @@
+{% include profile-set-nav.md resourceName="bundles" %}
+
+<script>
+// Move Markdown TOC below navigation
+var ref = document.querySelector('h4');
+var el = document.querySelector('div.markdown-toc');
+ref.parentNode.insertBefore(el, ref);
+</script>

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,0 +1,8 @@
+* [Full Specification (zip)](full-ig.zip)
+* [Package (tgz)](package.tgz)
+* [JSON Definitions (zip)](definitions.json.zip)
+* [JSON Examples (zip)](examples.json.zip)
+* [XML Definitions (zip)](definitions.xml.zip)
+* [XML Examples (zip)](examples.xml.zip)
+
+Note that a list of all artifacts in this IG can be found on the [Artifacts page](artifacts.html), and there is also a [table of contents](toc.html).

--- a/input/pagecontent/profiles.md
+++ b/input/pagecontent/profiles.md
@@ -2,62 +2,37 @@ This Implementation Guide (IG) includes Data Minimization (DM), which include on
 
 ### Profile groups
 
-<table class="table">
-<thead>
-    <tr>
-        <th>Profile Group</th>
-        <th>Primary Profiles (DM)</th>
-        <th>Fallback Profiles (AD)</th>
-        <th>Scope</th>
-    </tr>
-</thead>
-<tbody>
+<ul>
 {% for resource in site.data.profiles %}
-{% assign r = resource[1] %}
-{% if r.suppress == true %}
-{% else %}
-{% assign resourceName = resource[0] %}
-
-    {% for profileSet in r.profileSets %}
-    <tr>
-        {% if forloop.first == true %}
-            <td rowspan="{{ forloop.length }}">
-                <strong>{{ r.name }}</strong><br>
-                {{ r.description }}
-                {% if r.instructions %}
-                    {% capture url %}{{r.instructions}}{% endcapture %}
-                    <br><br>
-                    <span class="label label-success">Start here!</span>
-                    <a href="{{ r.instructions }}">Implementation instructions</a>
-                {% endif %}
-            </td>
-        {% endif %}
-        {% capture url %}StructureDefinition-{{ profileSet.slug }}-dm.html{% endcapture %}
-        <td><a href="{{ url }}">{{ profileSet.name }}</a></td>
-
-        {% capture url %}StructureDefinition-{{ profileSet.slug }}-ad.html{% endcapture %}
-        <td ><a href="{{ url }}">Fallback</a></td>
-
-        <td>{{ profileSet.scope }}</td>
-    </tr>
-    {% endfor %}
-{% endif %}
+    {% assign key = resource[0] %}
+    {% assign r = resource[1] %}
+    <li>
+        <strong id="profile-group-{{ key }}">
+            {% if r.instructions %}<a href="{{ r.instructions }}">{% endif %}
+            {{ r.name }}
+            {% if r.instructions %}</a>{% endif %}
+        </strong>
+        <br>
+        {{ r.description | markdownify }}
+    </li>
 {% endfor %}
-</tbody>
-</table>
+</ul>
 
 <hr style="margin-top: 3em; margin-bottom: 3em;">
 
 ### How to use profiles for implementation
 
+<span class="label">Note</span> This specification uses the conformance verbs SHALL, SHOULD, and MAY as defined in [RFC 2119].
+
 The recommended workflow for reading profiles of a given resource in this IG is as follows:
 
 1. Begin by reading the [IG's home page](index.html) and this page in their entirety.
-1. Then look at the table above for the specific Profile Group you need. Start by reviewing the "Implementation instructions" page for that Profile Group, if provided (will appear with <span class="label label-success">Start here!</span> in the table above and on each related profile's page).
-1. If multiple pairs of primary/fallback profiles are available within this Profile Group, choose the one with the **narrowest** applicable scope.
-1. Review the "Snapshot" tab on the primary (DM) profile. The elements listed here SHOULD/SHALL be included based on  `MustSupport` (<span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red;" >S</span> in the "Flags" column) and [cardinality](https://www.hl7.org/fhir/conformance-rules.html#cardinality) (in the "Card.") column. Elements **not** listed here SHOULD NOT or SHALL NOT be included. Details on interpreting cardinality and `MustSupport` for this IG are available [below](#mustsupport-interpretation).
-    - For more information about the data type for a given element, click the data type link in the "Type" column. This will bring you to the relevant portion of the FHIR specification for that data type.
-    - The "Description & Constraints" column has a short description of each element. Some elements may also have a "Binding" listed here, which indicates values SHALL come from the specified list. (This IG uses "Required" for all value set bindings, but other IGs may use [more flexible binding strengths](https://www.hl7.org/fhir/terminologies.html#strength).)
+1. Review this page in its entirety.
+1. Use the "Profile Groups" navigation menu, or the list of profile groups above to review the implementation instructions for each profile group in the IG.
+    1. If multiple pairs of primary/fallback profiles are available within this Profile Group, note that you should choose the pair with the **narrowest** applicable scope. For example, if there is a set of profiles for your country, you should use those rather than the generic set.
+    1. Review the "Snapshot" tab on the primary profile you plan to use within each profile group. The elements listed here SHOULD/SHALL be included based on  `MustSupport` (<span style="padding-left: 3px; padding-right: 3px; color: white; background-color: red;" >S</span> in the "Flags" column) and [cardinality](https://www.hl7.org/fhir/conformance-rules.html#cardinality) (in the "Card.") column. Elements **not** listed here SHOULD NOT or SHALL NOT be included. Details on interpreting cardinality and `MustSupport` for this IG are available [below](#mustsupport-interpretation).
+        - For more information about the data type for a given element, click the data type link in the "Type" column. This will bring you to the relevant portion of the FHIR specification for that data type.
+        - The "Description & Constraints" column has a short description of each element. Some elements may also have a "Binding" listed here, which indicates values SHALL come from the specified list. (This IG uses "Required" for all value set bindings, but other IGs may use [more flexible binding strengths](https://www.hl7.org/fhir/terminologies.html#strength).)
 1. For each element included in a given resource, review the detailed definition for the element in this IG. To find this, click the element's name in the "Snapshot" table of the relevant profile. The detailed definition may have more implementation and conformance information including applicable [invariants](https://www.hl7.org/fhir/conformance-rules.html#constraints).
 1. If you wish to [validate](#validation) your resource, start by validating against the primary (DM) profile for a given FHIR resource, and attempt to resolve any errors.
 
@@ -66,8 +41,6 @@ The recommended workflow for reading profiles of a given resource in this IG is 
     Issuers should be aware that adding in extraneous information to FHIR resources may not make it possible for the SMART Health Card to fit in a legible QR code. Issuers should refer to [SMART Health Cards Framework] for details.
 
 <hr style="margin-top: 3em; margin-bottom: 3em;">
-
-<span class="label">Note</span> This specification uses the conformance verbs SHALL, SHOULD, and MAY as defined in [RFC 2119].
 
 ### Conformance to profiles
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -35,12 +35,14 @@ pages:
     title: Home
   profiles.md:
     title: Profiles
-  laboratory-results-observation.md:
-    title: Laboratory Results Observation
-  vaccination.md:
-    title: Vaccination
   patient.md:
-    title: Patients
+    title: "Profile Group: Patients"
+  vaccination.md:
+    title: "Profile Group: Vaccination"
+  laboratory-results-observation.md:
+    title: "Profile Group: Laboratory Results Observation"
+  bundles.md:
+    title: "Profile Group: Bundles"
   StructureDefinition-shc-covid19-laboratory-bundle-resource-examples.md:
     title: Structure Definition SHC Covid 19 Laboratory Bundle Resource Examples
   StructureDefinition-shc-covid19-laboratory-result-observation-resource-examples.md:
@@ -61,6 +63,7 @@ pages:
     title: Contact
   conformance.md:
     title: Conformance
+  downloads.md:
+    title: Downloads
   artifacts.html:
     title: Artifacts Summary
-


### PR DESCRIPTION
- Improve top navbar with dropdown for profile groups
- Simplify profiles.html to only link to top level profile group pages rather than every single profile.
- Improve UX of navigation block that appears on each profile group page
- Add downloads page, with links to toc and artifacts
- Underline links everywhere for better usability
- Add bundles.html page (needed for consistency with simplified nav)

|Improvement|Old|New|
|-|-|-|
|Nav bar|<img width="656" alt="image" src="https://user-images.githubusercontent.com/110426/147888534-880eaec4-7006-4d59-8e9c-54d642a4f3f7.png">|<img width="692" alt="image" src="https://user-images.githubusercontent.com/110426/147888544-110db80f-e120-4b6d-8a6e-b2047852740e.png">|
|Profiles page|<img width="1139" alt="image" src="https://user-images.githubusercontent.com/110426/147888560-2902cd9c-8225-4d9a-9731-171d2a97af91.png">|<img width="807" alt="image" src="https://user-images.githubusercontent.com/110426/147888566-5af930d2-abe3-47bf-b5af-2e7008d714a4.png"><br>Only links to the top-level profile group pages now to make sure implementers see these pages. This is also *much* less confusing.|
|Nav on profile pages|<img width="1142" alt="image" src="https://user-images.githubusercontent.com/110426/147888592-b9432589-23e5-4b20-9b04-a18423fa26a6.png">|<img width="1129" alt="image" src="https://user-images.githubusercontent.com/110426/147888598-793ae85f-e15d-4ca4-95e9-28e44a8e600e.png"><br>Simplified layout, avoids out-of-place use of buttons.|




