### PR TITLE
Quote URLs to guarantee data type

### DIFF
--- a/input/fsh/value_sets.fsh
+++ b/input/fsh/value_sets.fsh
@@ -220,7 +220,7 @@ CodeSystem: IdentityAssuranceLevelCodeSystem
 Id: identity-assurance-level-code-system
 Title: "Identity Assurance Level Code System"
 Description: "Code representing identity assurance level, based on NIST 800-63-3"
-* ^url =  https://smarthealth.cards/ial
+* ^url =  "https://smarthealth.cards/ial"
 * ^copyright = "Copyright Computational Health Informatics Program, Boston Children's Hospital, Boston, MA as part of the [SMART Health Cards Framework](https://smarthealth.cards/ial). Licensed under CC-BY 4.0 (<https://creativecommons.org/licenses/by/4.0/>)."
 * #IAL1 "Name and birth date were self-asserted."
 * #IAL1.2 "An unspecified ID was used to verify name and birth date."


### PR DESCRIPTION
Upcoming changes in SUSHI version 3 allow for Instance assignment in rules that previously did not permit Instance assignment. This change is consistent with the existing FSH specification. The changes in this PR will help avoid errors when using SUSHI version 3.